### PR TITLE
Include distributions in timewarrior download

### DIFF
--- a/html/docs/timewarrior/download.html
+++ b/html/docs/timewarrior/download.html
@@ -105,7 +105,29 @@ $ sudo make install</pre>
               Do not submit patches based on the beta tarball.
               <a href="/docs/timewarrior/clone.html#patch">See here for details</a>.
             </p>
-          </div>
+
+            <a name="distributions"></a>
+            <h3>Distributions</h3>
+            <table class="table">
+              <tbody>
+              <tr>
+                <th>Distribution</th>
+                <th>Command</th>
+                <th>Available since</th>
+              </tr>
+              <tr>
+                <td><a href="https://www.archlinux.org/packages/community/x86_64/timew/">Arch Linux</a></td>
+                <td><code>sudo pacman -S timew</code></td>
+                <td>-</td>
+              </tr>
+              <tr>
+                <td><a href="https://packages.debian.org/search?keywords=timewarrior">Debian</a></td>
+                <td><code>sudo apt-get install timew</code></td>
+                <td>Stretch</td>
+              </tr>
+              </tbody>
+            </table>
+            </div>
 
           <br />
           <br />


### PR DESCRIPTION
Include a section about how to install timewarrior on distributions
which have packages for timewarrior.