### PR TITLE
Improve urgency documentation

### DIFF
--- a/html/docs/urgency.html
+++ b/html/docs/urgency.html
@@ -121,7 +121,7 @@ urgency.uda.priority.H.coefficient          6.0 # high Priority
 urgency.uda.priority.M.coefficient          3.9 # medium Priority
 urgency.uda.priority.L.coefficient          1.8 # low Priority
 urgency.active.coefficient                  4.0 # already started tasks
-urgency.scheduled.coefficient               4.0 # scheduled tasks
+urgency.scheduled.coefficient               5.0 # scheduled tasks
 urgency.age.coefficient                     2.0 # coefficient for age
 urgency.annotations.coefficient             1.0 # has annotations
 urgency.tags.coefficient                    1.0 # has tags

--- a/html/docs/urgency.html
+++ b/html/docs/urgency.html
@@ -158,6 +158,12 @@ urgency.blocked.coefficient                 -5.0 # blocked by other tasks</pre>
               term to have no effect on urgency.
             </p>
 
+            <p>
+              The urgency caused by tags and annotations is further modified
+              by the number of tags/annotations present: The factor is 0.8 for
+              one, 0.9 for two and 1.0 for more.
+            </p>
+
             <a name="custom"></a>
             <h4>Customizing Coefficients</h4>
             <p>

--- a/html/docs/urgency.html
+++ b/html/docs/urgency.html
@@ -120,14 +120,14 @@ urgency.blocking.coefficient                8.0 # blocking other tasks
 urgency.uda.priority.H.coefficient          6.0 # high Priority
 urgency.uda.priority.M.coefficient          3.9 # medium Priority
 urgency.uda.priority.L.coefficient          1.8 # low Priority
-urgency.active.coefficient                  4.0 # already started tasks
 urgency.scheduled.coefficient               5.0 # scheduled tasks
+urgency.active.coefficient                  4.0 # already started tasks
 urgency.age.coefficient                     2.0 # coefficient for age
 urgency.annotations.coefficient             1.0 # has annotations
 urgency.tags.coefficient                    1.0 # has tags
 urgency.project.coefficient                 1.0 # assigned to any project
-urgency.blocked.coefficient                 -5.0 # blocked by other tasks
-urgency.waiting.coefficient                 -3.0 # waiting task</pre>
+urgency.waiting.coefficient                 -3.0 # waiting task
+urgency.blocked.coefficient                 -5.0 # blocked by other tasks</pre>
 
             <p>
               The first coefficient has a value of 15.0, which is the highest

--- a/html/docs/urgency.html
+++ b/html/docs/urgency.html
@@ -127,10 +127,7 @@ urgency.annotations.coefficient             1.0 # has annotations
 urgency.tags.coefficient                    1.0 # has tags
 urgency.project.coefficient                 1.0 # assigned to any project
 urgency.blocked.coefficient                 -5.0 # blocked by other tasks
-urgency.waiting.coefficient                 -3.0 # waiting task
-urgency.user.project.&lt;project&gt;.coefficient  5.0 # specific project
-urgency.user.tag.&lt;tag&gt;.coefficient          5.0 # specific tag
-urgency.uda.&lt;name&gt;.coefficient              5.0 # specific UDA</pre>
+urgency.waiting.coefficient                 -3.0 # waiting task</pre>
 
             <p>
               The first coefficient has a value of 15.0, which is the highest


### PR DESCRIPTION
Hello,

this improves the urgency documentation and documents the tags/annotations factor which confused me when running `task info`.

Feel free to drop some commits (like sort, remove non-default values) if you don't like them.

Regards
Simon