### PR TITLE
Add link to the FAQ from docs

### DIFF
--- a/html/docs/help.html
+++ b/html/docs/help.html
@@ -77,7 +77,7 @@
             <a name="faq"></a>
             <h4>FAQ</h4>
             <p>
-              Take a look at the FAQ (coming soon) - you may find your question
+              Take a look at the <a href="/support/faq.html">FAQ</a> - you may find your question
               has already been asked and answered.
             </p>
 


### PR DESCRIPTION
Tested this by running `serve_local.sh`.

Also, I noticed that the link to the commands pdf (https://taskwarrior.org/download/task-latest.ref.pdf) at https://taskwarrior.org/docs/help.html is broken. However, it works locally.