### PR TITLE
Update Ubuntu package name

### DIFF
--- a/html/download/index.html
+++ b/html/download/index.html
@@ -165,8 +165,8 @@ $ sudo make install</pre>
                 <td>7.x Wheezy</td>
               </tr>
               <tr>
-                <td><a href="http://packages.ubuntu.com/search?keywords=task">Ubuntu</a></td>
-                <td><code>sudo apt-get install task</code></td>
+                <td><a href="http://packages.ubuntu.com/search?keywords=taskwarrior">Ubuntu</a></td>
+                <td><code>sudo apt-get install taskwarrior</code></td>
                 <td>10.10 Maverick Meerkat</td>
               </tr>
               <tr>


### PR DESCRIPTION
Since 16.04 Xenial, the package name has been 'taskwarrior'.