### PR TITLE
Fix incorrect description of "2 fortnight"

### DIFF
--- a/html/docs/durations.html
+++ b/html/docs/durations.html
@@ -235,7 +235,7 @@
                     <code>2fortnight</code><br />
                     <code>2sennight</code><br />
                   </td>
-                  <td>Fourteen days.</td>
+                  <td>Twenty eight days.</td>
                 </tr>
                 <tr>
                   <td>


### PR DESCRIPTION
Two fortnight represents twenty-eight days, not fourteen:

```
$ task calc 2 fortnight
P28D
```