### PR TITLE
Fix 404s with redirects

### DIFF
--- a/html/_redirects
+++ b/html/_redirects
@@ -5,3 +5,5 @@
 
 /download/task-latest.tar.gz /download/task-2.5.1.tar.gz
 /download/task-latest.ref.pdf /download/task-2.5.1.ref.pdf
+/download/tasksh-latest.tar.gz /download/tasksh-latest.tar.gz
+/download/taskserver/taskd-latest.tar.gz /download/taskserver/taskd-latest.tar.gz

--- a/html/download/index.html
+++ b/html/download/index.html
@@ -59,18 +59,6 @@
           </div>
 
           <div class="col-md-10 main">
-            <!--
-            <p>
-              <strong>Latest beta release:</strong>
-            </p>
-            <p>
-              <strong>taskwarrior 2.5.1.beta1</strong> (Released 2016-02-06): <a href="/download/task-2.5.1.beta1.tar.gz">task-2.5.1.beta1.tar.gz</a>
-              <br />
-              SHA1 cdec3ea0a140d264ecbe408c7195e6faca03463d
-              <br />
-              <a href="https://github.com/GothenburgBitFactory/taskwarrior/ChangeLog?at=refs%2Fheads%2F2.5.1">Changelog</a>
-            </p>
-            -->
             <p>
               <strong>Latest stable release:</strong>
             </p>


### PR DESCRIPTION
Noticed that https://github.com/GothenburgBitFactory/taskwarrior/issues/2003#issuecomment-377379268 ran into a 404 so did a bit more digging

I suppose a bot traversing the site for broken links would be best, but not up for that now... 😄 

Is there a way to reproduce and test this type of thing locally? I'm guessing not.

Noticed that https://taskwarrior.org/download/timew-1.1.1.tar.gz seemed to work despite a lack of redirect