### PR TITLE
add user & dev mail lists in support

### DIFF
--- a/html/support/index.html
+++ b/html/support/index.html
@@ -117,7 +117,7 @@
               <td>
                 <p>
                   You can ask for help at
-                  <a href="mailto:support@taskwarrior.org">support@taskwarrior.org</a>.
+                  <a href="mailto:support@taskwarrior.org">support@taskwarrior.org</a> or the <a href="https://groups.google.com/forum/#!forum/taskwarrior-user">User Mailinglist</a>.
                   We request that you first look around at the
                   <a href="/docs/">full online documentation</a>,
                   to give yourself a chance to answer your own question.
@@ -153,7 +153,7 @@
                   Are you a developer?  You might be looking for other tools,
                   continuous integration reports, or beta downloads.  Come on
                   over to our workshop at
-                  <a href="http://gothenburgbitfactory.org">gothenburgbitfactory.org</a>
+                  <a href="http://gothenburgbitfactory.org">gothenburgbitfactory.org</a> or ask questions at the <a href="https://groups.google.com/forum/#!forum/taskwarrior-dev">Developer Mailinglist</a>.
                 </p>
 
                 <p>


### PR DESCRIPTION
Not sure if we still want to support these? I discovered them at https://github.com/GothenburgBitFactory/taskserver-setup/blob/9261408da0bc1373e34ac2a62b6b83f896f32711/PITCHME.md#getting-help-2 and adopted the same format here. Tested locally (ran `python -m http.server` from html folder instead of using the script).