### PR TITLE
Spotfix: Refine Branch Disclaimer Text

### DIFF
--- a/html/download/index.html
+++ b/html/download/index.html
@@ -281,11 +281,11 @@ $ sudo make install</pre>
             <h5>Disclaimer:</h5>
             <p>
               The <code>master</code> branch represents the latest stable
-              release.  All other branches are development branches,
+              release.
             </p>
 
             <p>
-              All other branches are development branches, and are works in
+              <strong>All other branches are development branches</strong>, and are works in
               progress and may not pass all quality tests, therefore may harm
               your data.  While we welcome bug reports from the development
               branch, we do not guarantee proper or timely fixes.

--- a/html/download/index.html
+++ b/html/download/index.html
@@ -285,7 +285,7 @@ $ sudo make install</pre>
             </p>
 
             <p>
-              <strong>All other branches are development branches</strong>, and are works in
+              All other branches are development branches, and are works in
               progress and may not pass all quality tests, therefore may harm
               your data.  While we welcome bug reports from the development
               branch, we do not guarantee proper or timely fixes.


### PR DESCRIPTION
Adjusting the "all other branches..." disclaimer text so that it is not duplicated unnecessarily or trailing off.

**Before:**

![before](https://cldup.com/UWt-yAJSav-2000x2000.png)

**After:**

![after](https://cldup.com/K-1JaQ34uN.png)