### PR TITLE
fix "2 digit month hours" mistake in html/doc/dates.html

### DIFF
--- a/html/docs/dates.html
+++ b/html/docs/dates.html
@@ -150,7 +150,7 @@ $ task 1 modify due:2015-01-31</pre>
                 </tr>
                 <tr>
                   <td><code>H</code></td>
-                  <td>2 digit month hours, eg '01', '23'</td>
+                  <td>2 digit hours, eg '01', '23'</td>
                 </tr>
                 <tr>
                   <td><code>n</code></td>


### PR DESCRIPTION
i guess the `H` element of `rc.dateformat` stands for two digit hours.
thanks to u/wingtask for his verification, see:
https://www.reddit.com/r/taskwarrior/comments/fx1mak/what_are_month_hours/