### PR TITLE
Updates to serve_local.sh and context documentation

### DIFF
--- a/html/docs/context.html
+++ b/html/docs/context.html
@@ -192,13 +192,20 @@ work    +work or +freelance</pre>
               it, the context is cleared.
             </p>
 
+            <a name="add"></a>
+            <h4>Adding Task to a Context</h4>
+            <p>
+              To add a task to the <code>work</code> context:
+            <pre>$ task add +work Tell co-workers about Taskwarrior</pre>
+            </p>
+            
             <a name="impact"></a>
             <h4>Impact on Commands</h4>
             <p>
               All reports that accept filters will use the context if one is
               defined and set.
             </p>
-
+            
             <a name="related"></a>
             <h4>Related Support</h4>
             <p>

--- a/serve_local.sh
+++ b/serve_local.sh
@@ -15,6 +15,5 @@ else
     PORT=8000
     echo "If you wish to run the HTTP server on a different port, pass the port as an argument to this script."
 fi
-echo "Serving on 127.0.0.1:$PORT"
 
-python -c "import BaseHTTPServer as bhs, SimpleHTTPServer as shs; bhs.HTTPServer(('127.0.0.1', $PORT), shs.SimpleHTTPRequestHandler).serve_forever()"
+python -m http.server --bind 127.0.0.1 $PORT


### PR DESCRIPTION
serve_local.sh was Python 2 specific and would not run under Python 3.  Updated so that it ran under Python 3.  Removed echo statement as output is provided while running the command.

I could not find documentation that shows how to add a task to a context.  Updated context.html as a result.