### PR TITLE
Change Taskwarrior 2.5.3 release date to 2021-01-03

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -98,7 +98,7 @@
                     <td>
                       <!-- Item 1 -->
                       <div class="text-muted">
-                        <h4><a href="/news/news.20210125.html">News: Taskwarrior 2.5.3 released</a> <small>2020-01-03</small></h4>
+                        <h4><a href="/news/news.20210125.html">News: Taskwarrior 2.5.3 released</a> <small>2021-01-03</small></h4>
                         <p>
                           Taskwarrior 2.5.3 is released! Too much has happened over the past two years,
                           adding up to over 900 commits between 2.5.2 and 2.5.3.


### PR DESCRIPTION
Currently, on the homepage of taskwarrior.org it says that Taskwarrior 2.5.3 was released 2020-01-03. This should be 2021-01-03 instead