### PR TITLE
fix typo

### DIFF
--- a/html/docs/terminology.html
+++ b/html/docs/terminology.html
@@ -1169,7 +1169,7 @@ $ task _get 8ad2e3db-914d-4832-b0e6-72fa04f6e331.id
           <dd>
             <p>
               Verbosity refers to the output Taskwarrior generates. For example
-              if you run a report, the output might looks like this (data
+              if you run a report, the output might look like this (data
               excluded for clarity):
             </p>
 


### PR DESCRIPTION
Change 'looks' to 'look' in verbosity terminology entry