### PR TITLE
Fixed FAQ typo, no projects is project == '', not project != ''

### DIFF
--- a/html/support/faq.html
+++ b/html/support/faq.html
@@ -155,7 +155,7 @@
               </p>
               <pre>$ task project.none: list
 $ task project: list
-$ task project != '' list
+$ task project == '' list
 $ task -PROJECT list</pre>
               <p>
                 The last example makes use of a virtual tag designed for this
@@ -168,7 +168,7 @@ $ task -PROJECT list</pre>
 
               <pre>$ task project.any: list
 $ task project.not: list
-$ task project == '' list
+$ task project != '' list
 $ task +PROJECT list</pre>
             </li>
           </ul>


### PR DESCRIPTION
Hey! I have fixed FAQ typo, no projects is project == '', not project != ''. I have swapped these. Please review my PR.
Thanks!
fixes #326 