### PR TITLE
update for 2.6.2 release

### DIFF
--- a/html/_redirects
+++ b/html/_redirects
@@ -3,7 +3,7 @@
 # Syntax: <redirect-from>  <redirect-to>  [<redirect code>]
 # See https://www.netlify.com/docs/redirects/
 
-/download/task-latest.tar.gz /download/task-2.6.1.tar.gz
+/download/task-latest.tar.gz /download/task-2.6.2.tar.gz
 /download/task-latest.ref.pdf /download/task-2.5.3.ref.pdf
 /download/tasksh-latest.tar.gz /download/tasksh-latest.tar.gz
 /download/taskserver/taskd-latest.tar.gz /download/taskserver/taskd-latest.tar.gz

--- a/html/docs/build.html
+++ b/html/docs/build.html
@@ -103,11 +103,11 @@ $ make                               # Just build it.</pre>
             <h3>Building the Dev Branch</h3>
             <p>
               The dev branch is always the highest numbered branch, in this
-              example, <code>2.6.0</code>.
+              example, <code>2.6.2</code>.
             </p>
 
               <pre>$ cd taskwarrior.git
-$ git checkout 2.6.0                 # Dev branch
+$ git checkout 2.6.2                 # Dev branch
 $ git submodule init                 # Register submodule
 $ git submodule update               # Get the submodule
 $ cmake -DCMAKE_BUILD_TYPE=debug .   # debug or release, default: neither

--- a/html/docs/first_time.html
+++ b/html/docs/first_time.html
@@ -140,7 +140,7 @@ $ sudo apt-get install make</pre>
               development branch:
             </p>
 
-            <pre>$ git clone --recursive -b 2.6.0 https://github.com/GothenburgBitFactory/taskwarrior.git taskwarrior.git
+            <pre>$ git clone --recursive -b 2.6.2 https://github.com/GothenburgBitFactory/taskwarrior.git taskwarrior.git
 Cloning into 'taskwarrior.git'...
 remote: Counting objects: 55345, done.
 remote: Compressing objects: 100% (12655/12655), done.
@@ -166,14 +166,14 @@ $</pre>
 
             <pre>$ cd taskwarrior.git
 $ git branch -a
-* 2.6.0
-  remotes/origin/2.6.0
-  remotes/origin/HEAD -&gt; origin/2.6.0
+* 2.6.2
+  remotes/origin/2.6.2
+  remotes/origin/HEAD -&gt; origin/2.6.2
   remotes/origin/master
 $</pre>
 
             <p>
-              Here we see that 2.6.0 is the highest-numbered branch, and therefore
+              Here we see that 2.6.2 is the highest-numbered branch, and therefore
               the current development branch.  If there were a higher numbered branch,
               you would want to use that by doing this:
             </p>
@@ -315,8 +315,8 @@ Runtime:                        32.50 seconds</pre>
 
             <pre>$ cd taskwarrior.git
 $ git status
-On branch 2.6.0
-Your branch is up-to-date with 'origin/2.6.0'.
+On branch 2.6.2
+Your branch is up-to-date with 'origin/2.6.2'.
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -326,7 +326,7 @@ Changes not staged for commit:
 no changes added to commit (use "git add" and/or "git commit -a")
 $ git add doc/man/task.1.in
 $ git commit -m 'Docs: corrected typo in the main man page'
-[2.6.0 ddbb07e] Docs: corrected typo in the main man page
+[2.6.2 ddbb07e] Docs: corrected typo in the main man page
  1 file changed, 1 insertion(+)
 $</pre>
 

--- a/html/download/index.html
+++ b/html/download/index.html
@@ -63,9 +63,9 @@
               <strong>Latest stable release:</strong>
             </p>
             <p>
-              <strong>taskwarrior 2.6.1</strong> (Released 2021-10-19): <a href="/download/task-2.6.1.tar.gz" class='piwik_download'>task-2.6.1.tar.gz</a>
+              <strong>taskwarrior 2.6.2</strong> (Released 2022-03-16): <a href="/download/task-2.6.2.tar.gz" class='piwik_download'>task-2.6.2.tar.gz</a>
               <br />
-              SHA3 227926cee3af705e662466f9d5a6eac5a6fabbea810079f47039f4ed
+              SHA3 92e547ac6bb88659e674877a19cb88dc9687be2ab989f0279b04f286
               <br />
               <a href="https://github.com/GothenburgBitFactory/taskwarrior/blob/stable/ChangeLog">Changelog</a>
             </p>
@@ -102,9 +102,9 @@
             </p>
 
             <pre>$ ls
-task-2.6.1.tar.gz
-$ tar xzvf task-2.6.1.tar.gz
-$ cd task-2.6.1
+task-2.6.2.tar.gz
+$ tar xzvf task-2.6.2.tar.gz
+$ cd task-2.6.2
 $ cmake -DCMAKE_BUILD_TYPE=release .
 ...
 $ make

--- a/html/index.html
+++ b/html/index.html
@@ -98,6 +98,28 @@
                     <td>
                       <!-- Item 1 -->
                       <div class="text-muted">
+                        <h4><a href="/news/news.20220316.html">News: Taskwarrior 2.6.2 released</a> <small>2021-10-02</small></h4>
+                        <p>
+                          Since Taskwarrior strives to be _the very best_, we are proud to announce the availability of the 2.6.2
+                          bugfix release. Sometimes being best also means best at releasing versions with problems that need
+                          to be fixed 🙂 and (hopefully, eventually) catching them all.
+                        </p>
+
+                        <p>
+                          This bugfix-only release improves the upgrade path to 2.6.x, prevents corruption of the depends attribute
+                          when syncing, provides better support for detecting invalid write contexts and fixes a handful of small
+                          regressions introduced in our recent <a href="https://github.com/GothenburgBitFactory/taskwarrior/releases/tag/v2.6.0">2.6.0 release</a>.
+                          The <a href="https://github.com/GothenburgBitFactory/taskwarrior/blob/f030154ef6a24c673bdb78feefd31c8f5179411f/ChangeLog">full changelog
+                          is once again available</a> in our traditional plaintext form.
+                        </p>
+
+                        <p>
+                          This is a recommended upgrade for all Taskwarrior users.  <a href="/download/">Download here</a>.
+                        </p>
+                      </div>
+
+                      <!-- Item 2 -->
+                      <div class="text-muted">
                         <h4><a href="/news/news.20211002.html">News: Taskwarrior 2.6.0 released</a> <small>2021-10-02</small></h4>
                         <p>
                           Taskwarrior team is happy to announce the release of Taskwarrior 2.6.0, which brings a number of improvements
@@ -137,7 +159,7 @@ $ task
                         </p>
                       </div>
 
-                      <!-- Item 2 -->
+                      <!-- Item 3 -->
                       <div class="text-muted">
                         <h4><a href="/news/news.20210125.html">News: Taskwarrior 2.5.3 released</a> <small>2021-01-03</small></h4>
                         <p>
@@ -156,7 +178,7 @@ $ task
                         </p>
                       </div>
 
-                      <!-- Item 3 -->
+                      <!-- Item 4 -->
                       <div class="text-muted">
                         <h4><a href="/news/news.20191123.html">News: Timewarrior 1.2.0 released</a> <small>2019-11-23</small></h4>
                         <p>
@@ -180,7 +202,7 @@ $ task
                         </p>
                       </div>
 
-                      <!-- Item 4 -->
+                      <!-- Item 5 -->
                       <div class="text-muted">
                         <h4><a href="/news/news.20180204.html">2018 Plans</a> <small>2018-02-04</small></h4>
                         <p>
@@ -194,7 +216,7 @@ $ task
                         </p>
                       </div>
 
-                      <!-- Item 5 -->
+                      <!-- Item 6 -->
                       <div class="text-muted">
                         <h4><a href="/news/news.20180203.2.html">Timewarrior 1.1.1 released</a> <small>2018-02-03</small></h4>
                         <p>
@@ -225,7 +247,7 @@ $ task
                         </p>
                       </div>
 
-                      <!-- Item 6 -->
+                      <!-- Item 7 -->
                       <div class="text-muted">
                         <h4><a href="/news/news.20180203.html">Services Migration</a> <small>2018-02-03</small></h4>
                         <p>
@@ -247,7 +269,7 @@ $ task
                         </p>
                       </div>
 
-                      <!-- Item 7 -->
+                      <!-- Item 8 -->
                       <div class="text-muted">
                         <h4><a href="/news/news.20180129.html">FOSDEM 2018: Taskwarrior Presence</a> <small>2018-01-29</small></h4>
                         <p>
@@ -316,7 +338,7 @@ $ task
         <div class="alert alert-danger">
           <h4>Get the Code</h4>
           <div class="small">
-            Stable: <a class="alert-link" href="/download/task-2.6.1.tar.gz">Taskwarrior 2.6.1</a><br />
+            Stable: <a class="alert-link" href="/download/task-2.6.2.tar.gz">Taskwarrior 2.6.2</a><br />
             Stable: <a class="alert-link" href="/download/taskd-1.1.0.tar.gz">Taskserver 1.1.0</a><br />
             Stable: <a class="alert-link" href="/download/tasksh-1.2.0.tar.gz">Tasksh 1.2.0</a><br />
             Stable: <a class="alert-link" href="https://timewarrior.net/">Timewarrior 1.4.3</a><br />


### PR DESCRIPTION
I noticed 2.6.2 was [released](https://github.com/GothenburgBitFactory/taskwarrior/releases/tag/v2.6.2) but not on the site yet.