### PR TITLE
Make command properly formatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This repository contains the content of the taskwarrior.org site.
 
 
 ## To Clone this Repository:
-
-   git clone https://github.com/GothenburgBitFactory/tw.org.git
+```sh
+git clone https://github.com/GothenburgBitFactory/tw.org.git
+```
 
 
 ## Instruction For Updating tw.org/html/tools


### PR DESCRIPTION
On line 8, the `git clone https://github.com/GothenburgBitFactory/tw.org.git` command isn't formatted as a command. I made it so that it is.