### PR TITLE
Fix typo in example on how to list all projects

### DIFF
--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -167,7 +167,7 @@ What are all the projects I have ever used?
 ```
 $ task rc.list.all.projects=1 projects
 $ task rc.list.all.projects=1 _projects
-$ task _unique projects
+$ task _unique project
 ```
 
 ## Tags


### PR DESCRIPTION
This PR fixes a small typo in the example on how to list all projects, as the command `_unique` only works with the column name