### PR TITLE
Fix formatting in FAQ

### DIFF
--- a/content/support/faq.md
+++ b/content/support/faq.md
@@ -119,8 +119,7 @@ Most color themes already support this.
 
 Taskwarrior can do date math, so use this:
 
-    $ task add ...
-due:eom wait:due-2days
+    $ task add ... due:eom wait:due-2days
 
 That `due-2days` value is evaluated by Taskwarrior, using the value you specified for the due date and subtracting two days.
 You can also verify that date using the `calc` command:

--- a/content/support/faq.md
+++ b/content/support/faq.md
@@ -386,7 +386,3 @@ If you installed Taskwarrior from a binary package, uninstall and reinstall Task
 In tasksh like most linux shell, you can navigate the list of your last input commands by using the UP/DOWN arrows for history navigation and PageUp/PageDown for prefixed history navigation (other names may apply here).
 
 With prefixed history navigation you can start typing a command, say mod and by using PageUp/PageDown you will only browse history commands that start by mod, whereas full history ignores any input that already exists and simply navigates history in order.
-
-A: if ( e.g. after changing from 2.3.0 to 2.5.1) in tasksh the
-
-Tasksh supports `libreadline`, but make sure the development version is installed, and rebuild.


### PR DESCRIPTION
- Fix formatting on due:eom example
- Remove crufty docs. I'm not sure what this bit was originally attached to, but it wasn't this section here.
