### PR TITLE
Use shortcodes to refer to release data

### DIFF
--- a/content/docs/taskserver/tarball.md
+++ b/content/docs/taskserver/tarball.md
@@ -31,7 +31,7 @@ You should check for the latest stable release here: <https://taskwarrior.org/do
 You can download the tarball with `curl`, as an example of just one of many ways to download the tarball.
 
 ```
-$ curl -LO https://github.com/GothenburgBitFactory/taskserver/releases/download/v1.1.0/taskd-1.1.0.tar.gz
+$ curl -LO {{< project "taskd" "stable" "url" >}}
 ```
 
 ## Build
@@ -39,8 +39,8 @@ $ curl -LO https://github.com/GothenburgBitFactory/taskserver/releases/download/
 Expand the tarball, and build the Taskserver.
 
 ```
-$ tar xzf taskd-1.1.0.tar.gz
-$ cd taskd-1.1.0
+$ tar xzf taskd-{{< project "taskd" "stable" "version" >}}.tar.gz
+$ cd taskd-{{< project "taskd" "stable" "version" >}}
 $ cmake -DCMAKE_BUILD_TYPE=release .
 ...
 $ make

--- a/content/download/index.md
+++ b/content/download/index.md
@@ -8,9 +8,9 @@ title: "Taskwarrior - What's next?"
 
 ## Latest stable release
 
-**taskwarrior 3.0.0** (Released 2024-03-24):
-[task-3.0.0.tar.gz](https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v3.0.0/task-3.0.0.tar.gz)  
-SHA256 30f397081044f5dc2e5a0ba51609223011a23281cd9947ea718df98d149fcc83  
+**Taskwarrior {{< current_release "version" >}}** (Released {{< current_release "date" >}}):
+[task-{{< current_release "version" >}}.tar.gz]({{< current_release "url" >}})  
+SHA256 {{< current_release "sha256" >}}  
 [Changelog](https://github.com/GothenburgBitFactory/taskwarrior/blob/stable/ChangeLog)
 
 Command reference taskwarrior 2.5.3:
@@ -25,9 +25,9 @@ This transcript illustrates a typical installation:
 
 ```
 $ ls
-task-3.0.0.tar.gz
-$ tar xzvf task-3.0.0.tar.gz
-$ cd task-3.0.0
+task-{{< current_release "version" >}}.tar.gz
+$ tar xzvf task-{{< current_release "version" >}}.tar.gz
+$ cd task-{{< current_release "version" >}}
 $ cmake -DCMAKE_BUILD_TYPE=release .
 ...
 $ make

--- a/data/projects.json
+++ b/data/projects.json
@@ -3,7 +3,7 @@
     "name": "Taskwarrior",
     "stable": {
       "version": "3.0.0",
-      "url": "/download/task-3.0.0.tar.gz"
+      "url": "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v3.0.0/task-3.0.0.tar.gz"
     },
     "develop": {
       "version": "3.0.1",

--- a/data/releases.json
+++ b/data/releases.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "3.0.0",
-    "date": "2021-10-19",
+    "date": "2024-03-24",
     "name": "task-3.0.0",
     "tarball": "task-3.0.0.tar.gz",
     "url": "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v3.0.0/task-3.0.0.tar.gz",


### PR DESCRIPTION
Manage release related data in `releases.json` (for Taskwarrior) or `projects.json` (for all other projects, e.g. Taskserver), include them via shortcodes into the webpages.