### PR TITLE
Fix taskserver links

### DIFF
--- a/content/docs/taskserver/tarball.md
+++ b/content/docs/taskserver/tarball.md
@@ -31,7 +31,7 @@ You should check for the latest stable release here: <https://taskwarrior.org/do
 You can download the tarball with `curl`, as an example of just one of many ways to download the tarball.
 
 ```
-$ curl -LO {{< project "taskd" "stable" "url" >}}
+$ curl -LO https://github.com/GothenburgBitFactory/taskserver/releases/download/v1.1.0/taskd-1.1.0.tar.gz
 ```
 
 ## Build
@@ -39,8 +39,8 @@ $ curl -LO {{< project "taskd" "stable" "url" >}}
 Expand the tarball, and build the Taskserver.
 
 ```
-$ tar xzf taskd-{{< project "taskd" "stable" "version" >}}.tar.gz
-$ cd taskd-{{< project "taskd" "stable" "version" >}}
+$ tar xzf taskd-1.1.0.tar.gz
+$ cd taskd-1.1.0
 $ cmake -DCMAKE_BUILD_TYPE=release .
 ...
 $ make


### PR DESCRIPTION
This is causing hugo builds to break, although curiously CI is not catching that.

Taskserver is deprecated and won't have another release, so hard-coding the version for now seems fine.