### PR TITLE
Add rust dependencies to build instructions

### DIFF
--- a/content/docs/build.md
+++ b/content/docs/build.md
@@ -14,6 +14,8 @@ You'll need these tools:
 - [cmake](https://cmake.org)
 - make
 - C++ compiler, currently gcc 4.7+ or clang 3.3+ for full C++11 support
+- rustc
+- cargo
 - Python 2.7 or later (for tests)
 - Bash (for tests)
 


### PR DESCRIPTION
I recently built the current stable version of tw on a fresh machine and I noticed, that cmake was complaining about missing rust dependencies which are not part of the docs. Installing the  `rustc` and `cargo` packages on ubuntu seemed to be sufficient, hence this PR.