### PR TITLE
Communicate that Taskserver is deprecated

### DIFF
--- a/content/docs/3rd-party.md
+++ b/content/docs/3rd-party.md
@@ -40,7 +40,6 @@ We encourage you to create such add-ons, but in doing so, there are some rules t
   When reading the JSON for a task, there may be attributes that you have never encountered before.
   If this is the case, you must not modify them in any way.
   This not only makes your application future-proof, but allows it to tolerate UDAs from other data sources.
-  It also prevents the Taskserver from stripping out *your* data.
 
 ## Guidelines
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,7 +5,7 @@ viewport: 'width=device-width, initial-scale=1'
 layout: single
 ---
 
-{{< lead >}}Here is the complete set of Taskwarrior and Taskserver documentation.{{< /lead >}}
+{{< lead >}}Here is the complete set of Taskwarrior documentation.{{< /lead >}}
 
 ## Getting Started
 
@@ -56,7 +56,7 @@ layout: single
 - [Deprecated Features](deprecated/)
 - [Philosophy](philosophy/)
 
-## Taskserver
+## Taskserver (deprecated, only compatible with Taskwarrior 2.x)
 - [Why do I need a Taskserver?](taskserver/why/)
 - [Taskserver Setup Guide](https://gothenburgbitfactory.org/taskserver-setup/)
 - [Taskserver Troubleshooting Guide](https://gothenburgbitfactory.org/taskserver-troubleshooting/)

--- a/content/docs/commands/_index.md
+++ b/content/docs/commands/_index.md
@@ -33,7 +33,7 @@ Version-specific features are labelled with the version in which they were first
   * `purge` {{< label >}}2.6.0{{< /label >}} - Completely removes tasks, rather than change status to `deleted`
   * `start` - Start working on a task, make active
   * `stop` - Stop working on a task, no longer active
-  * [`synchronize` - Syncs tasks with Taskserver](synchronize/)
+  * [`synchronize` - Syncs tasks with other instances](synchronize/)
   * `undo` - Revert last change
   * `version` - Version details and copyright
 

--- a/content/docs/commands/synchronize.md
+++ b/content/docs/commands/synchronize.md
@@ -4,12 +4,14 @@ title: "Taskwarrior - Synchronize"
 
 # synchronize
 
-The `synchronize` command, which first appeared in version 2.3.0, connects your Taskwarrior client to a [Taskserver](../../#taskserver) instance, uploads local changes, downloads remote changes, and merges the results.
-You can have several clients making local changes all of which sync to a single server instance, and they will all be kept up to date.
+The `synchronize` command, which first appeared in version 2.3.0, allows your Taskwarrior instance to share tasks with other instances.
+You can have several instances making local changes all of which sync to a single server, and they will all be kept up to date, with changes flowing from instance to instance.
 
-The Taskserver is designed to handle multiple clients that may not have synchronized recently, all with local changes, with only temporary network connectivity, and still do the right thing.
+The synchronization system is designed to handle multiple clients that may not have synchronized recently, all with local changes, with only temporary network connectivity, and still do the right thing.
 
-With a [correctly configured](../../taskserver/taskwarrior/) client, adding a task, or modifying an existing task, creates a local change that needs to be synced.
+With a correctly configured Taskwarrior, adding a task, or modifying an existing task, creates a local change that needs to be synced.
+See the `task-sync(5)` manpage for information on configuring Taskwarrior.
+
 Taskwarrior will add a footnote to all output if a `synchronize` is needed.
 
 ```
@@ -39,7 +41,7 @@ Sync successful.  1 changes uploaded.
 
 This shows a successful sync, uploading our one change.
 If there were remote changes to download, the message would include that.
-It is safe to sync as often as you wish, although it does waste some bandwidth setting up a TLS connection with the Taskserver.
+It is safe to sync as often as you wish.
 
 ```
 $ task sync
@@ -51,7 +53,7 @@ Sync successful.  No changes.
 ## Limitations
 
 - Network connectivity is required in order to sync.
-- Taskwarrior must be [correctly configured](../../taskserver/taskwarrior/) to connect to a Taskserver.
+- Taskwarrior must be correctly configured to connect to a server.
 
 ## See Also
 

--- a/content/docs/deprecated.md
+++ b/content/docs/deprecated.md
@@ -85,6 +85,8 @@ None yet.
 
 ## Taskserver
 
+NOTE: Taskserver itself is deprecated and only compatible with Taskwarrior 2.x.
+
 ### Client Allow/Deny List [removed in 1.1.0]
 
 Taskserver initially supported the `client.allow` and `client.deny` settings which filtered connections.

--- a/content/docs/history_td.md
+++ b/content/docs/history_td.md
@@ -2,6 +2,8 @@
 title: "Taskwarrior - Taskserver Release History"
 ---
 
+NOTE: Taskserver is deprecated and only compatible with Taskwarrior 2.x.
+
 # Release History
 
 This is a summary of the Taskserver [ChangeLog](https://github.com/GothenburgBitFactory/taskserver/blob/master/ChangeLog) file.

--- a/content/docs/taskserver/troubleshooting-sync.md
+++ b/content/docs/taskserver/troubleshooting-sync.md
@@ -10,7 +10,15 @@ Please review the steps you took.
 
 It is always a good idea to make sure that you are using the latest release of Taskwarrior and Taskserver, not just because bugs are fixed that may help you, but also because the solutions below are geared toward the current releases.
 
-If you upgrade from an older release of Taskserver, you will need to follow the [upgrade instructions](../upgrade/).
+If you upgrade from an older release of Taskserver, you will need to follow the [upgrade instructions](../upgrade-3/).
+
+# Taskwarrior 3.x
+
+No suggestions yet - make a PR to add your troubleshooting tip here!
+
+# Taskwarrior 2.x / Taskserver
+
+Note that Taskserver does not work with TaskWarrior 3.x.
 
 ## Problems
 

--- a/content/docs/taskserver/why.md
+++ b/content/docs/taskserver/why.md
@@ -2,6 +2,8 @@
 title: "Taskwarrior - Taskserver Why?"
 ---
 
+NOTE: Taskserver is deprecated and only compatible with Taskwarrior 2.x.
+
 # Why Do I Need a Taskserver?
 
 You may not need a Taskserver.

--- a/content/docs/terminology.md
+++ b/content/docs/terminology.md
@@ -4,7 +4,7 @@ title: "Taskwarrior - Terminology"
 
 # Terminology
 
-Taskwarrior and Taskserver use a lot of terminology that is not obvious.
+Taskwarrior uses a lot of terminology that is not obvious.
 Those terms are defined here.
 
 ## active
@@ -117,14 +117,6 @@ Taskwarrior has several built-in reports, some of which are modifiable via confi
 Additionally, you can create your own Custom Reports, where you can define the command, attributes show, length, filter, sorting and breaks.
 
 The [Report](../report/) gives a detailed explanation of how to use, modify and create reports.
-
-## daemon
-
-A daemon is the name given to a process that runs without interaction as a background process.
-Various server products are run as daemons, and are automatically launched on startup.
-Typically, daemons are named ending with 'd'.
-
-Taskserver (taskd) can be run as a daemon, using the `--daemon` command line argument.
 
 ## dateformat
 
@@ -474,12 +466,9 @@ The substitution syntax allows text replacement in task description and annotati
 
 ## sync
 
-Synchronization is a service provided by the Taskserver, and allows multiple sync clients to share data.
-The Taskserver knows how to merge tasks and handle incremental updates to minimize bandwidth used.
-
-Although you can achieve a similar capability using one of the many file-sharing services, the merging that happens is not aware of how to merge tasks.
-
-Starting with Taskwarrior 2.3.0, there is a `sync` command that can be configured to talk to a Taskserver.
+Synchronization is a process that and allows multiple Taskwarrior instances to share data.
+Each instance periodically connects to the server to gather changes made by other instances and to send changes made locally.
+This is initiated with the `task sync` command.
 
 ## tag
 

--- a/content/docs/triage.md
+++ b/content/docs/triage.md
@@ -13,7 +13,7 @@ Everything else can.
 ## Initial Assessment
 
 - Move the issue to the correct project.
-  for example, sometimes an issue is reported as a Taskwarrior bug, but is better handled in TaskChampion.
+  For example, sometimes an issue is reported as a Taskwarrior bug, but is better handled in TaskChampion.
 - Move the issue to the correct type, which means bug, feature or improvement.
   Sometimes it is not easy to distinguish, and some folks are clever about reporting a feature request in the form of a bug, assuming that bugs gets more attention than feature requests.
   We're not fooled by that.

--- a/content/docs/triage.md
+++ b/content/docs/triage.md
@@ -13,7 +13,7 @@ Everything else can.
 ## Initial Assessment
 
 - Move the issue to the correct project.
-  Sometimes an issue is reported as a Taskserver bug, but it is a sync issue with Taskwarrior.
+  for example, sometimes an issue is reported as a Taskwarrior bug, but is better handled in TaskChampion.
 - Move the issue to the correct type, which means bug, feature or improvement.
   Sometimes it is not easy to distinguish, and some folks are clever about reporting a feature request in the form of a bug, assuming that bugs gets more attention than feature requests.
   We're not fooled by that.

--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -23,7 +23,6 @@ There is an active and well-attended \#taskwarrior channel on libera.chat.
 ## Documentation
 
 There is [full online documentation](../docs/) to help you diagnose problems, or learn about features and usage.
-There is a very good chance that you are looking for either our [Taskserver Setup Guide](https://gothenburgbitfactory.org/taskserver-setup/) or [Taskserver Troubleshooting Guide](https://gothenburgbitfactory.org/taskserver-troubleshooting/).
 
 ## Manual pages
 

--- a/themes/bootstrap/layouts/index.html
+++ b/themes/bootstrap/layouts/index.html
@@ -48,10 +48,6 @@
           <p>
             Try our <a href="support/faq/">FAQ</a>, a growing list of curated questions and answers.
           </p>
-          <p>
-            <a href="https://gothenburgbitfactory.org/taskserver-setup/">Taskserver Setup Guide</a><br>
-            <a href="https://gothenburgbitfactory.org/taskserver-troubleshooting/">Taskserver Troubleshooting Guide</a>.
-          </p>
         </div>
       </div>
       {{ partial "get_the_code.html" . }}


### PR DESCRIPTION
This leaves the documentation of Taskserver in place, but removes unnecessary links to it and tries to indicate to new audiences that this is not for use with newer versions of Taskwarrior.

Addresses https://github.com/GothenburgBitFactory/taskwarrior/issues/3293