### PR TITLE
Clarify that SQLite is used for storage in docs/start.md

### DIFF
--- a/content/docs/start.md
+++ b/content/docs/start.md
@@ -33,8 +33,8 @@ Five good reasons to use Taskwarrior
 
 4. Taskwarrior is open in as many ways as it can be:
    - It is [free and open source](https://github.com/GothenburgBitFactory/taskwarrior), using the MIT license
-   - It uses human-readable text files for storage.
-     It imports and exports [JSON](https://github.com/GothenburgBitFactory/taskwarrior/blob/develop/doc/devel/rfcs/task.md), so your data is never held captive
+   - It uses SQLite database files for storage, which are easily readable. Direct modification is possible but not recommended due to internal consistency requirements.
+   - It imports and exports [JSON](https://github.com/GothenburgBitFactory/taskwarrior/blob/develop/doc/devel/rfcs/task.md), so your data is never held captive
    - There is [DOM](../dom/) access and a [Hook script API](../hooks/)
    - There are many available free and open [extension scripts](../../tools/)
    - There is [Vit](https://gothenburgbitfactory.org/projects/vit/), a curses-based UI


### PR DESCRIPTION
Also, add bullet point for JSON import/export, which, I guess, was always meant to be a separate point from the previous one.

Fixes: #835