### PR TITLE
Un-deprecate attribute modifiers and boolean configuration values

### DIFF
--- a/content/docs/deprecated.md
+++ b/content/docs/deprecated.md
@@ -35,11 +35,6 @@ The `sync` command in 2.3.0 replaces this functionality.
 
 Starting in 2.4.0, shadow files are replaced by an equivalent hook mechanism.
 
-### Attribute Modifiers [deprecated since 2.4.0]
-
-Attribute modifiers such as `project.startswith:Ab` are all deprecated starting with version 2.4.0.
-In the example above, the replacement is an algebraic expression, `project ~ ^ab`, which uses the `~` regex match operator, and `^Ab` which is a regular expression.
-
 ### Bare Word Search Terms [deprecated since 2.4.0]
 
 Simple words being interpreted as search terms is deprecated in 2.4.0 and will be removed in a future release.
@@ -68,12 +63,6 @@ The `_ids`, `_projects`, `_tags`, and `_uuids` helper commands are deprecated in
 ### Virtual tag `DUETODAY` [deprecated since 2.6.0]
 
 The `DUETODAY` virtual tag is a synonym for the more consistently named `TODAY` virtual tag.
-
-### Use of Boolean configuration values other than `0` or `1` [deprecated since 2.6.0]
-
-Deprecated use of alternate Boolean configuration settings.
-Use values "0" for off, and "1" for on.
-Avoid used of "on", "off", "true", "t", "false", "f", "yes", "y", "no", "n".
 
 ### DOM references: context.* [deprecated since 2.6.0]
 

--- a/content/support/faq.md
+++ b/content/support/faq.md
@@ -200,11 +200,7 @@ It's a bash script, and easily modifiable.
 ### Q: Why have attribute modifiers (`urgency.over:10`) rather than the more readable and algebraic form (`urgency>10`)?
 
 Taskwarrior already supports both forms.
-The attribute modifier form is older and predates more complex filter support.
 The algebraic form requires that you escape any characters that the shell will otherwise interpret.
-
-At some point the attribute modifier form will likely be deprecated.
-The algebraic form is already much more capable.
 
     $ task help
     ...


### PR DESCRIPTION
Also, I removed some sentences in the FAQ which might suggest that one form of "attribute modifiers" is preferred over the other. I think the dev's understanding is that each form has its pros and cons. But feel free to change that back if you want.

Fixes: #867