### PR TITLE
update build instructions and point to discord server

### DIFF
--- a/content/docs/build.md
+++ b/content/docs/build.md
@@ -67,6 +67,7 @@ In particular, the [vramsteg](https://gothenburgbitfactory.org/projects/vramsteg
 ```
 $ cd taskwarrior.git
 $ cmake --build build --target build_tests
+$ ctest --test-dir build
 ```
 
 This will build and run the whole test suite.

--- a/content/docs/build.md
+++ b/content/docs/build.md
@@ -16,12 +16,11 @@ You'll need these tools:
 - C++ compiler, currently gcc 4.7+ or clang 3.3+ for full C++11 support
 - rustc
 - cargo
-- Python 2.7 or later (for tests)
+- Python 3 or later (for tests)
 - Bash (for tests)
 
 You'll need these libraries:
 
-- [GnuTLS](https://www.gnutls.org/)
 - libuuid (unless on Darwin/BSD)
 
 Specifically the development versions, `uuid-dev` on Debian, for example.
@@ -40,23 +39,22 @@ The `stable` branch always represents the more recently released version, and sh
 
 ```
 $ cd taskwarrior.git
-$ git checkout stable                # 'stable' is the current branch matching the latest release.
-$ cmake -DCMAKE_BUILD_TYPE=release . # 'release' for performance.
-$ make                               # Just build it.
+$ git checkout stable                             # 'stable' is the current branch matching the latest release.
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release  # Out-of-source build in Release mode
+$ cmake --build build                             # Just build it.
 ```
 
 ## Building the Dev Branch
 
 The `develop` branch contains the latest changes.
 Choose this branch if you want to work on the code, or if you want to try out the latest features.
+More information on testing and building can be seen [here](https://github.com/GothenburgBitFactory/taskwarrior/blob/develop/doc/devel/contrib/development.md).
 
 ```
 $ cd taskwarrior.git
-$ git checkout develop               # Dev branch
-$ git submodule init                 # Register submodule
-$ git submodule update               # Get the submodule
-$ cmake -DCMAKE_BUILD_TYPE=debug .   # debug or release, default: neither
-$ make VERBOSE=1                     # Shows details
+$ git checkout develop                          # Dev branch
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug  # Out-of-source build in Debug mode
+$ cmake --build build                           # Just build it.
 ```
 
 Build the debug type if you want symbols in the binary.
@@ -67,11 +65,11 @@ There are scripts to facilitate running the test suite.
 In particular, the [vramsteg](https://gothenburgbitfactory.org/projects/vramsteg/) utility provides blinkenlights for test progress.
 
 ```
-$ cd taskwarrior.git/test
-$ make VERBOSE=1     # Shows details
-$ ./run_all          # Runs all tests silently > all.log
-$ ./problems         # Find errors in all.log
+$ cd taskwarrior.git
+$ cmake --build build --target build_tests
 ```
+
+This will build and run the whole test suite.
 
 ## Submitting a Patch
 

--- a/content/docs/start.md
+++ b/content/docs/start.md
@@ -29,7 +29,7 @@ Five good reasons to use Taskwarrior
 
 3. Taskwarrior has an active and friendly community, providing support and various forms of help to new and experienced users. [Start here](../../support/) for a list of support options.
    Need an immediate answer - check your man pages and [online docs](../).
-   Need to ask someone a question? try IRC #taskwarrior on libera.chat.
+   Need to ask someone a question? Checkout our [Discord Server](https://discord.gg/eRXEHk8w62).
 
 4. Taskwarrior is open in as many ways as it can be:
    - It is [free and open source](https://github.com/GothenburgBitFactory/taskwarrior), using the MIT license

--- a/content/docs/start.md
+++ b/content/docs/start.md
@@ -102,7 +102,7 @@ There are several ways for you to get a copy of Taskwarrior:
 - Install a binary package.
   Your operating system probably already has a binary package available.
   These packages are usually named 'task'.
-- Download a release tarball, from [here](../../download/), then make sure you have libuuid-dev (maybe called uuid-dev) and gnutls-dev installed.
+- Download a release tarball, from [here](../../download/), then make sure you have libuuid-dev (maybe called uuid-dev) installed.
   Then using cmake, GCC 4.7 / Clang 3.3, [build Taskwarrior](../build/).
 - Using [git](https://git-scm.com), clone the code repository, switch to the current development branch, and [build Taskwarrior](../build/).
 

--- a/content/download/index.md
+++ b/content/download/index.md
@@ -9,8 +9,8 @@ title: "Taskwarrior - What's next?"
 ## Latest stable release
 
 **Taskwarrior {{< current_release "version" >}}** (Released {{< current_release "date" >}}):
-[task-{{< current_release "version" >}}.tar.gz]({{< current_release "url" >}})  
-SHA256 {{< current_release "sha256" >}}  
+[task-{{< current_release "version" >}}.tar.gz]({{< current_release "url" >}})
+SHA256 {{< current_release "sha256" >}}
 [Changelog](https://github.com/GothenburgBitFactory/taskwarrior/blob/stable/ChangeLog)
 
 Command reference taskwarrior 2.5.3:
@@ -28,11 +28,11 @@ $ ls
 task-{{< current_release "version" >}}.tar.gz
 $ tar xzvf task-{{< current_release "version" >}}.tar.gz
 $ cd task-{{< current_release "version" >}}
-$ cmake -DCMAKE_BUILD_TYPE=release .
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+$ cmake --build build
 ...
-$ make
 ...
-$ sudo make install
+$ sudo cmake --install build
 ```
 
 Please note, that Cygwin is not supported anymore.
@@ -48,7 +48,7 @@ On startup, task will check to see if it can find the configuration file and tas
 | [Debian sid](https://packages.debian.org/sid/utils/taskwarrior)                       | `sudo apt-get install taskwarrior`                                                                                                                                                                                          | Debian sid                 |
 | [Debian](https://backports.debian.org/Instructions/)                                  | `sudo apt-get install taskwarrior`                                                                                                                                                                                          | 7.x Wheezy                 |
 | [Ubuntu](https://packages.ubuntu.com/search?keywords=taskwarrior)                     | `sudo apt-get install taskwarrior`                                                                                                                                                                                          | 10.10 Maverick Meerkat     |
-| [Fedora](https://apps.fedoraproject.org/packages/task)                                | `yum install task`                                                                                                                                                                                                          | Fedora 18                  |
+| [Fedora](https://apps.fedoraproject.org/packages/task)                                | `sudo dnf install task`                                                                                                                                                                                                          | Fedora 18                  |
 | Red Hat Enterprise Linux                                                              | `task` has been submitted to the EPEL repositories of Fedora.<br/>Please refer to the [EPEL documentation](https://fedoraproject.org/wiki/EPEL/FAQ#howtouse)                                                                | \-                         |
 | [OpenSUSE](https://software.opensuse.org/package/taskwarrior?search_term=taskwarrior) | `zypper install taskwarrior`                                                                                                                                                                                                | openSUSE 12.2              |
 | [Archlinux](https://archlinux.org/packages/extra/x86_64/task/)                        | `pacman -S task`                                                                                                                                                                                                            | \-                         |

--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -16,9 +16,9 @@ Please [report any abuse](mailto:support@gothenburgbitfactory.org).
 Your questions have been compiled into a [multi-product FAQ](faq/).
 Take a look here - there is a good chance your question is already answered.
 
-## IRC
+## Discord
 
-There is an active and well-attended \#taskwarrior channel on libera.chat.
+If you want to get in touch with the community, use the [Discord Server](https://discord.gg/eRXEHk8w62) and hit the [#help-wanted](https://discord.com/channels/796949983734661191/796988698813923398) channel.
 
 ## Documentation
 

--- a/content/support/faq.md
+++ b/content/support/faq.md
@@ -145,6 +145,8 @@ You just start/stop tasks using Taskwarrior, and Timewarrior will start/stop tra
 If you start/stop in Timewarrior, it does not control Taskwarrior.
 
 ## Taskserver
+Taskserver is generally deprecated and can only be used with the Taskwarrior 2.6.2 release.
+Please read over [Upgrading to Taskwarrio 3](/docs/upgrade-3/) for more details on the upgrade and a brief explanaition of the new storage backend.
 
 ### Q: How do I set up Taskserver to use LetsEncrypt certs?
 


### PR DESCRIPTION
I noticed that we have quite some old build instructions online and also highlight the IRC chat. 

These are now at least partially updated to reflect the current project status.