### PR TITLE
Remove default Hugo taxonomies 'tags' and 'categories'

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,8 @@ publishDir = "html"
 [params]
 description = "Taskwarrior is Free and Open Source Software that manages your TODO list from the command line."
 
+[taxonomies]
+
 [markup]
     [markup.tableOfContents]
         endLevel = 2


### PR DESCRIPTION
This removes the empty pages:
- https://taskwarrior.org/tags
- https://taskwarrior.org/categories

Source: https://gohugo.io/content-management/taxonomies/#example-removing-default-taxonomies