### PR TITLE
Fix cURL command to latest version information

### DIFF
--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -476,7 +476,8 @@ $ task all
 Do I have the latest released version?
 
 ```
-$ curl https://gothenburgbitfactory.org/latest/task
+$ curl -L https://gothenburgbitfactory.org/task/latest
+{{< current_release "version" >}}
 $ task --version 
-2.5.3
+{{< current_release "version" >}}
 ```


### PR DESCRIPTION
This fixes the cURL command in the example on how to check whether one runs the latest version of Taskwarrior

cURL cannot handle Hugos browser redirects of alias pages, so we use 'the correct one'. 
Also, use Hugo shortcut to display current Taskwarrior version.

Closes #1201